### PR TITLE
Add the Traffic Fetch File

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Idea Pool of SCoRe Lab
 Here we are gathering all the project ideas we get for future reference.
 
-1. 
+1. [Basic Implementation of Traffic Routes](https://github.com/LeWarEnds/Traffic-Implementation-Of-BassaExtension)

--- a/Traffic.py
+++ b/Traffic.py
@@ -1,0 +1,15 @@
+def hit_site(url):
+    print url
+    r = requests.get(url,stream = True)
+    print r.headers
+    print r.encoding
+    print r.status_code
+    print r.json()
+    print requests.get(url,stream=True)
+    print r.request.headers
+    print r.response.headers
+    for line in r.iter_lines():
+        print line
+    data = r.text
+    soup = BeautifulSoup(data)
+    return soup

--- a/Traffic.py
+++ b/Traffic.py
@@ -1,4 +1,4 @@
-def hit_site(url):
+def site_traffic(url):
     print url
     r = requests.get(url,stream = True)
     print r.headers


### PR DESCRIPTION
**Python FIle for Capturing Traffic**

These are attempted by my `site_traffic` function within my router's reach and no VPN or similar items were used in this process.

✔️ While using the file with fiddler, Approximate amount of traffic is captured. I have used `www.google.com` as an example. So, while getting the process following details are captured.
![trafficcapture](https://user-images.githubusercontent.com/35108041/50287951-841cf900-048a-11e9-8da1-25a4bfa6e9dd.PNG)

✔️ Also, navigating to one of the websites after getting the data about traffic, that whole data code is stored on this [website]( http://www.googletagmanager.com//gtm.js?id=GTM-B76Z
)(only for this case)

> This link is used as an example of a particular case which was released while getting the traffic details.

✔️ These are the report for the single packet received after the traffic check.

`# | Result | Protocol | Host | URL | Body | Caching | Content-Type | Process | Comments | Custom
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
6 | 200 | HTTP | prourl.itsecure.co.in:8080 | /URLCategorizerService/URLCategorize | 235 |   |   | emlproxy:4656 |   |  `


✔️ Also, when there is an error while capturing the data about traffic, these are the results in the statistics box.
![error](https://user-images.githubusercontent.com/35108041/50288343-af541800-048b-11e9-9018-92599f03b663.PNG)
